### PR TITLE
Make it work

### DIFF
--- a/api/generated/photon/index.js
+++ b/api/generated/photon/index.js
@@ -62,7 +62,7 @@ class Photon {
         const internal = options.__internal || {};
         const engineConfig = internal.engine || {};
         this.engine = new runtime_1.Engine({
-            cwd: engineConfig.cwd || "/Users/notrab/now-photon/api/prisma/",
+            cwd: engineConfig.cwd || "/Users/divyendusingh/Documents/prisma/support/now-photon-bug/api/prisma/",
             debug: debugEngine,
             datamodel,
             prismaPath: engineConfig.binaryPath || undefined

--- a/api/index.js
+++ b/api/index.js
@@ -30,6 +30,7 @@ const photon = new Photon({
   __internal: {
     engine: {
       cwd: path.join(__dirname, '../api/prisma/'),
+      binaryPath: path.join(__dirname, '../api/prisma-mac'),
     },
   },
 })

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,6 @@
 {
   "private": true,
   "scripts": {
-    "postinstall": "prisma2 generate"
   },
   "dependencies": {
     "apollo-server-micro": "^2.6.7",


### PR DESCRIPTION
- added binary
- `cwd` (that looks like a local path on my machine) in generated photon is this bug https://github.com/prisma/photonjs/issues/95, once this is fixed all the `__internal` hacks would go away! 
- I ran into the error `Database creation error: Sqlite data source must point to an existing file.` after this which normally works via `prisma2 lift save` and `prisma2 lift up`, it would be interesting how this works with `now dev` since they are moving files around. If it gives you a lot of trouble, move the db file outside of the project and use an absolute path. 